### PR TITLE
Fix infinite loop and add a test case

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "caseless"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Unicode caseless matching"
 repository = "https://github.com/SimonSapin/rust-caseless"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@ impl<I> Iterator for CaseFold<I> where I: Iterator<Item = char> {
         let c = self.queue[0];
         if c != '\0' {
             self.queue[0] = self.queue[1];
+            self.queue[1] = '\0';
             return Some(c)
         }
         self.chars.next().map(|c| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,3 +113,17 @@ impl<I> Iterator for CaseFold<I> where I: Iterator<Item = char> {
          high.and_then(|h| h.checked_mul(3)).and_then(|h| h.checked_add(queue_len)))
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::default_case_fold_str;
+
+    #[test]
+    fn test_strs() {
+        assert_eq!(default_case_fold_str("Test Case"), "test case");
+        assert_eq!(default_case_fold_str("Teſt Caſe"), "test case");
+        assert_eq!(default_case_fold_str("spiﬃest"), "spiffiest");
+        assert_eq!(default_case_fold_str("straße"), "strasse");
+    }
+}
+


### PR DESCRIPTION
I found the source of the `ﬃ` bug, which was that `queue[1]` could never change. Setting it to `'\0'` after copying its value to `queue[0]` fixes the bug.

To demonstrate that the bug is fixed, I added a test case that case-folds a few strings, one of them containing the ﬃ ligature.