### PR TITLE
Support no_std builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,6 @@
 language: rust
+
+script:
+  - cargo build
+  - cargo test
+  - cargo test --no-default-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,9 @@ build = "src/build.rs"
 regex = "1.0"
 
 [dependencies]
-unicode-normalization = "0.1"
+unicode-normalization = { version = "0.1", optional = true }
+
+[features]
+default = ["alloc", "normalization"]
+alloc = []
+normalization = ["unicode-normalization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,10 +1,13 @@
 [package]
 name = "caseless"
-version = "0.2.1"
+version = "0.2.2"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Unicode caseless matching"
 repository = "https://github.com/SimonSapin/rust-caseless"
 license = "MIT"
+keywords = ["unicode", "string", "case-insensitive", "normalization", "no_std"]
+categories = ["text-processing"]
+readme = "README.md"
 
 build = "src/build.rs"
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # rust-caseless
 
 Unicode caseless matching
+
+This crate can be used without libstd, when build without the default `alloc`
+and `normalization` features.


### PR DESCRIPTION
This adds two features, both enabled by default:

* `normalization` - enables the `canonical_caseless_match` and
  `compatibility_caseless_match` methods, which require the
  `unicode_normalization` crate.

* `alloc` - enables the `default_case_fold_str` convenience method,
  which requires allocating a `String`.

Disabling both these features allows use of this crate for case folding in
`no_std` programs.