### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "caseless"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Simon Sapin <simon.sapin@exyr.org>"]
 description = "Unicode caseless matching"
 repository = "https://github.com/unicode-rs/rust-caseless"


### PR DESCRIPTION
@Manishearth would it be possible to get a release including the recently merged PRs? This would allow [comrak](https://lib.rs/crates/comrak) to be built without depending on `regex` which would be a nice compile time win for a project I am working on.

Also, I believe:
- https://github.com/unicode-rs/rust-caseless/pull/14
- and https://github.com/unicode-rs/rust-caseless/pull/18

could be closed as superceded by https://github.com/unicode-rs/rust-caseless/pull/22